### PR TITLE
removed FLBTime because uint64 interface cannot be converted to int64

### DIFF
--- a/examples/out_gstdout/out_gstdout.go
+++ b/examples/out_gstdout/out_gstdout.go
@@ -2,9 +2,9 @@ package main
 
 import "github.com/fluent/fluent-bit-go/output"
 import (
+	"C"
 	"fmt"
 	"unsafe"
-	"C"
 )
 
 //export FLBPluginRegister
@@ -42,9 +42,9 @@ func FLBPluginFlush(data unsafe.Pointer, length C.int, tag *C.char) int {
 		}
 
 		// Print record keys and values
-		timestamp := ts.(output.FLBTime)
+		timestamp := ts
 		fmt.Printf("[%d] %s: [%s, {", count, C.GoString(tag),
-			timestamp.String())
+			timestamp)
 		for k, v := range record {
 			fmt.Printf("\"%s\": %v, ", k, v)
 		}


### PR DESCRIPTION
The code as written cannot be converted into FLBTime. Unix time is consistently displayed in the Time field across plugins; perhaps this is an issue that can be addressed in fluent-bit code base?

Disclaimer: I'm a novice at golang and would be more than happy to learn about a different way to re-type the time and display it as human readable.