### PR TITLE
output: multiple go plugin instances

### DIFF
--- a/examples/out_gstdout/out_gstdout.go
+++ b/examples/out_gstdout/out_gstdout.go
@@ -1,23 +1,24 @@
 package main
 
-import "github.com/fluent/fluent-bit-go/output"
 import (
+	"C"
 	"fmt"
 	"unsafe"
-	"C"
+
+	"github.com/fluent/fluent-bit-go/output"
 )
 
 //export FLBPluginRegister
-func FLBPluginRegister(ctx unsafe.Pointer) int {
-	return output.FLBPluginRegister(ctx, "gstdout", "Stdout GO!")
+func FLBPluginRegister(def unsafe.Pointer) int {
+	return output.FLBPluginRegister(def, "gstdout", "Stdout GO!")
 }
 
 //export FLBPluginInit
 // (fluentbit will call this)
-// ctx (context) pointer to fluentbit context (state/ c code)
-func FLBPluginInit(ctx unsafe.Pointer) int {
+// plugin (context) pointer to fluentbit context (state/ c code)
+func FLBPluginInit(plugin unsafe.Pointer) int {
 	// Example to retrieve an optional configuration parameter
-	param := output.FLBPluginConfigKey(ctx, "param")
+	param := output.FLBPluginConfigKey(plugin, "param")
 	fmt.Printf("[flb-go] plugin parameter = '%s'\n", param)
 	return output.FLB_OK
 }

--- a/examples/out_multiinstance/Makefile
+++ b/examples/out_multiinstance/Makefile
@@ -1,0 +1,5 @@
+all:
+	go build -buildmode=c-shared -o out_multiinstance.so
+
+clean:
+	rm -rf *.so *.h *~

--- a/examples/out_multiinstance/README.md
+++ b/examples/out_multiinstance/README.md
@@ -1,0 +1,3 @@
+This example demonstrates using a plugin where there are multiple instances
+and `FLBPluginFlushCtx` is used to disambiguate multiple instances of the
+output plugin.

--- a/examples/out_multiinstance/out.go
+++ b/examples/out_multiinstance/out.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"C"
+	"log"
+	"unsafe"
+
+	"github.com/fluent/fluent-bit-go/output"
+)
+
+//export FLBPluginRegister
+func FLBPluginRegister(def unsafe.Pointer) int {
+	return output.FLBPluginRegister(def, "multiinstance", "Testing multiple instances.")
+}
+
+//export FLBPluginInit
+func FLBPluginInit(plugin unsafe.Pointer) int {
+	id := output.FLBPluginConfigKey(plugin, "id")
+	log.Printf("[multiinstance] id = %q", id)
+	// Set the context to point to any Go variable
+	output.FLBPluginSetContext(plugin, unsafe.Pointer(&id))
+	return output.FLB_OK
+}
+
+//export FLBPluginFlush
+func FLBPluginFlush(data unsafe.Pointer, length C.int, tag *C.char) int {
+	log.Print("Flush called for unknown instance")
+	return output.FLB_OK
+}
+
+//export FLBPluginFlushCtx
+func FLBPluginFlushCtx(ctx, data unsafe.Pointer, length C.int, tag *C.char) int {
+	// Cast context back into the original type for the Go variable
+	id := (*string)(ctx)
+	log.Printf("Flush called for id: %s", *id)
+
+	dec := output.NewDecoder(data, int(length))
+
+	for {
+		ret, _, _ := output.GetRecord(dec)
+		if ret != 0 {
+			break
+		}
+	}
+
+	return output.FLB_OK
+}
+
+//export FLBPluginExit
+func FLBPluginExit() int {
+	return output.FLB_OK
+}
+
+func main() {
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/fluent/fluent-bit-go
+
+require github.com/ugorji/go v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/ugorji/go v1.1.4 h1:j4s+tAvLfL3bZyefP2SEWmhBzmuIlH/eqNuPdFPgngw=
+github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/output/flb_output.h
+++ b/output/flb_output.h
@@ -20,25 +20,28 @@
 #ifndef FLBGO_OUTPUT_H
 #define FLBGO_OUTPUT_H
 
-#include <stdio.h>
-
 struct flb_api {
     char *(*output_get_property) (char *, void *);
 };
 
-struct flbgo_output_plugin {
-    char *name;
-    struct flb_api *api;
-    void *o_ins;
-    int (*cb_init)();
-    int (*cb_flush)(void *, size_t, char *);
-    int (*cb_exit)(void *);
+struct flb_plugin_proxy_context {
+    void *remote_context;
 };
 
-char *output_get_property(char *key, void *ctx)
+/* This structure is used for initialization.
+ * It matches the one in proxy/go/go.c in fluent-bit source code.
+ */
+struct flbgo_output_plugin {
+    void *_;
+    struct flb_api *api;
+    struct flb_output_instance *o_ins;
+    struct flb_plugin_proxy_context *context;
+};
+
+char *output_get_property(char *key, void *plugin)
 {
-    struct flbgo_output_plugin *plugin = ctx;
-    return plugin->api->output_get_property(key, plugin->o_ins);
+    struct flbgo_output_plugin *p = plugin;
+    return p->api->output_get_property(key, p->o_ins);
 }
 
 #endif

--- a/output/flb_plugin.h
+++ b/output/flb_plugin.h
@@ -29,8 +29,10 @@
 #define FLB_PROXY_OUTPUT_PLUGIN    2
 #define FLB_PROXY_GOLANG          11
 
-/* Structure used for registration, it match the one on flb_plugin_proxy.h */
-struct flb_plugin_proxy {
+/* This structure is used for registration.
+ * It matches the one in flb_plugin_proxy.h in fluent-bit source code.
+ */
+struct flb_plugin_proxy_def {
     int type;
     int proxy;
     int flags;

--- a/output/output.go
+++ b/output/output.go
@@ -23,44 +23,51 @@ package output
 #include "flb_output.h"
 */
 import "C"
-import "fmt"
-import "unsafe"
+import (
+	"unsafe"
+)
 
 // Define constants matching Fluent Bit core
-const FLB_ERROR               =  C.FLB_ERROR
-const FLB_OK                  =  C.FLB_OK
-const FLB_RETRY               =  C.FLB_RETRY
+const (
+	FLB_ERROR = C.FLB_ERROR
+	FLB_OK    = C.FLB_OK
+	FLB_RETRY = C.FLB_RETRY
 
-const FLB_PROXY_OUTPUT_PLUGIN =  C.FLB_PROXY_OUTPUT_PLUGIN
-const FLB_PROXY_GOLANG        =  C.FLB_PROXY_GOLANG
+	FLB_PROXY_OUTPUT_PLUGIN = C.FLB_PROXY_OUTPUT_PLUGIN
+	FLB_PROXY_GOLANG        = C.FLB_PROXY_GOLANG
+)
 
 // Local type to define a plugin definition
-type FLBPlugin C.struct_flb_plugin_proxy
+type FLBPluginProxyDef C.struct_flb_plugin_proxy_def
 type FLBOutPlugin C.struct_flbgo_output_plugin
 
 // When the FLBPluginInit is triggered by Fluent Bit, a plugin context
 // is passed and the next step is to invoke this FLBPluginRegister() function
 // to fill the required information: type, proxy type, flags name and
 // description.
-func FLBPluginRegister(ctx unsafe.Pointer, name string, desc string) int {
-	p := (*FLBPlugin) (unsafe.Pointer(ctx))
+func FLBPluginRegister(def unsafe.Pointer, name, desc string) int {
+	p := (*FLBPluginProxyDef)(def)
 	p._type = FLB_PROXY_OUTPUT_PLUGIN
 	p.proxy = FLB_PROXY_GOLANG
 	p.flags = 0
-	p.name  = C.CString(name)
+	p.name = C.CString(name)
 	p.description = C.CString(desc)
 	return 0
 }
 
 // Release resources allocated by the plugin initialization
-func FLBPluginUnregister(ctx unsafe.Pointer) {
-	p := (*FLBPlugin) (unsafe.Pointer(ctx))
-	fmt.Printf("[flbgo] unregistering %v\n", p)
+func FLBPluginUnregister(def unsafe.Pointer) {
+	p := (*FLBPluginProxyDef)(def)
 	C.free(unsafe.Pointer(p.name))
 	C.free(unsafe.Pointer(p.description))
 }
 
-func FLBPluginConfigKey(ctx unsafe.Pointer, key string) string {
+func FLBPluginConfigKey(plugin unsafe.Pointer, key string) string {
 	_key := C.CString(key)
-	return C.GoString(C.output_get_property(_key, unsafe.Pointer(ctx)))
+	return C.GoString(C.output_get_property(_key, plugin))
+}
+
+func FLBPluginSetContext(plugin, ctx unsafe.Pointer) {
+	p := (*FLBOutPlugin)(plugin)
+	p.context.remote_context = ctx
 }


### PR DESCRIPTION
This change:
- implements the functionality for multiple output instances.
- adds an example for multiple plugin instances.
- general clean up to make things more clear and consistent.
- adds support for go modules.

@jasonkeene