### PR TITLE
output: free C string after use

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -64,7 +64,9 @@ func FLBPluginUnregister(def unsafe.Pointer) {
 
 func FLBPluginConfigKey(plugin unsafe.Pointer, key string) string {
 	_key := C.CString(key)
-	return C.GoString(C.output_get_property(_key, plugin))
+	value := C.GoString(C.output_get_property(_key, plugin))
+	C.free(unsafe.Pointer(_key))
+	return value
 }
 
 var contexts []interface{}


### PR DESCRIPTION
```go
// Go string to C string
// The C string is allocated in the C heap using malloc.
// It is the caller's responsibility to arrange for it to be
// freed, such as by calling C.free (be sure to include stdlib.h
// if C.free is needed).
func C.CString(string) *C.char
```