### PR TITLE
Mark go:nocheckptr explicitly

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -71,6 +71,10 @@ func FLBPluginConfigKey(plugin unsafe.Pointer, key string) string {
 
 var contexts []interface{}
 
+// FLBPluginSetContext may set up potentially faulting address.
+// It would construct and use an invalid pointer,
+// so mark it as nocheckptr.
+//go:nocheckptr
 func FLBPluginSetContext(plugin unsafe.Pointer, ctx interface{}) {
 	i := len(contexts)
 	contexts = append(contexts, ctx)


### PR DESCRIPTION
Because FLBPLuginSetContext would set up faulting address.
This function is setter, so we should use it at our own risk.

Fixes #26.

Signed-off-by: Hiroshi Hatake <cosmo0920.oucc@gmail.com>