### PR TITLE
Basic type sanity checking on GetRecord to prevent panics

### DIFF
--- a/output/decoder.go
+++ b/output/decoder.go
@@ -77,6 +77,10 @@ func GetRecord(dec *FLBDecoder) (ret int, ts interface{}, rec map[interface{}]in
 	}
 
 	slice := reflect.ValueOf(m)
+	if slice.Kind() != reflect.Slice || slice.Len() != 2 {
+		return -1, 0, nil
+	}
+
 	t := slice.Index(0).Interface()
 	data := slice.Index(1)
 

--- a/output/decoder.go
+++ b/output/decoder.go
@@ -78,7 +78,7 @@ func GetRecord(dec *FLBDecoder) (ret int, ts interface{}, rec map[interface{}]in
 
 	slice := reflect.ValueOf(m)
 	if slice.Kind() != reflect.Slice || slice.Len() != 2 {
-		return -1, 0, nil
+		return -2, 0, nil
 	}
 
 	t := slice.Index(0).Interface()


### PR DESCRIPTION
Related to:

https://github.com/fluent/fluent-bit-go/issues/34
https://github.com/fluent/fluent-bit-go/issues/29

The decoder currently expects all data passed to FLBPluginFlush/FLBPluginFlushCtx to be a 2 length slice of [timestamp, map data].  But this is not always true and when it is not, the decoder panics, crashes and loses whatever data is pending in memory.

I do not know why this case occurs, but the debugging I have done shows that sometimes, "data" is just a 0 value int64.  This is likely something coming from fluent-bit itself rather than any of the go code.  It is worth noting that some of the native C plugins in fluent-bit are also doing content checking of the data value, so I am guessing this issue isn't unique to the plugin proxy.

This PR implements some basic sanity checks on the structure of the flushed data and skips anything that isn't a 2 len slice.  I am not an expert on Go, nor an expert on fluent-bit internals, so let me know if there is a better way.

Currently, I cannot run my go plugin in production without this patch, as it crashes every few minutes or so.