### PR TITLE
Feature/fix flb plugin exit ctx

### DIFF
--- a/examples/out_gstdout/go.mod
+++ b/examples/out_gstdout/go.mod
@@ -1,4 +1,4 @@
-module github.com/fluent/fluent-bit-go/examples/gstdout
+module github.com/fluent/fluent-bit-go/examples/out_gstdout
 
 go 1.14
 

--- a/examples/out_multiinstance/go.mod
+++ b/examples/out_multiinstance/go.mod
@@ -1,4 +1,4 @@
-module github.com/fluent/fluent-bit-go/examples/multiinstance
+module github.com/fluent/fluent-bit-go/examples/out_multiinstance
 
 go 1.14
 

--- a/examples/out_multiinstance/out.go
+++ b/examples/out_multiinstance/out.go
@@ -12,6 +12,7 @@ import (
 
 //export FLBPluginRegister
 func FLBPluginRegister(def unsafe.Pointer) int {
+	log.Printf("[multiinstance] Register called")
 	return output.FLBPluginRegister(def, "multiinstance", "Testing multiple instances.")
 }
 
@@ -78,7 +79,16 @@ func FLBPluginExit() int {
 
 //export FLBPluginExitCtx
 func FLBPluginExitCtx(ctx unsafe.Pointer) int {
+	// Type assert context back into the original type for the Go variable
+	id := output.FLBPluginGetContext(ctx).(string)
+	log.Printf("[multiinstance] Exit called for id: %s", id)
 	return output.FLB_OK
+}
+
+//export FLBPluginUnregister
+func FLBPluginUnregister(def unsafe.Pointer) {
+	log.Print("[multiinstance] Unregister called")
+	output.FLBPluginUnregister(def)
 }
 
 func main() {


### PR DESCRIPTION
Make changes to examples/out_multiinstance to fail on https://github.com/fluent/fluent-bit-go/issues/49 and better log these multiple instances lifecycle. during fixinghttps://github.com/fluent/fluent-bit/pull/6469 fix in main fluent-bit repository.