### PR TITLE
Fix typo in README

### DIFF
--- a/examples/out_multiinstance/README.md
+++ b/examples/out_multiinstance/README.md
@@ -22,7 +22,7 @@ description:
 ```go
 //export FLBPluginRegister
 func FLBPluginRegister(def unsafe.Pointer) int {
-	return output.FLBPluginRegister(ctx, "multiinstance", "Testing multiple instances")
+	return output.FLBPluginRegister(def, "multiinstance", "Testing multiple instances")
 }
 ```
 


### PR DESCRIPTION
This PR addresses typos found in both the README file and the documentation site. The changes made are as follows:

1. Corrected the misspelled word "ctx" in the Sample Code section of the README file.
2. Fixed the same typo found on the documentation site (URL: https://docs.fluentbit.io/manual/development/golang-output-plugins#build-a-go-plugin).

The changes made will improve the readability and consistency of the project's documentation. Please review and consider merging this fix.

If any additional action is required to update the documentation site, kindly let me know and I'll be happy to assist.
Please note that I might have misunderstood the context or made an error in my observation. If that's the case, I apologize for any confusion and please feel free to disregard my suggested changes.
